### PR TITLE
Make bigquery_avro_tools_test py3 compatible

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_avro_tools_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_avro_tools_test.py
@@ -21,7 +21,10 @@ import json
 import logging
 import unittest
 
-import avro.schema
+try:
+  from avro.schema import Parse  # avro-python3 library for Python 3
+except ImportError:
+  from avro.schema import parse as Parse  # avro library for Python 2
 import fastavro
 
 from apache_beam.io.gcp import bigquery_avro_tools
@@ -79,32 +82,29 @@ class TestBigQueryToAvroSchema(unittest.TestCase):
     fastavro.parse_schema(avro_schema)
 
     # Test that schema can be parsed correctly by avro
-    parsed_schema = avro.schema.parse(json.dumps(avro_schema))
+    parsed_schema = Parse(json.dumps(avro_schema))
     # Avro RecordSchema provides field_map in py3 and fields_dict in py2
     field_map = getattr(parsed_schema, "field_map", None) or \
       getattr(parsed_schema, "fields_dict", None)
 
     self.assertEqual(
-        field_map["number"].type, avro.schema.parse(json.dumps("long")))
+        field_map["number"].type, Parse(json.dumps("long")))
     self.assertEqual(
-        field_map["species"].type,
-        avro.schema.parse(json.dumps(["null", "string"])))
+        field_map["species"].type, Parse(json.dumps(["null", "string"])))
     self.assertEqual(
-        field_map["quality"].type,
-        avro.schema.parse(json.dumps(["null", "double"])))
+        field_map["quality"].type, Parse(json.dumps(["null", "double"])))
     self.assertEqual(
-        field_map["quantity"].type,
-        avro.schema.parse(json.dumps(["null", "long"])))
+        field_map["quantity"].type, Parse(json.dumps(["null", "long"])))
     self.assertEqual(
         field_map["birthday"].type,
-        avro.schema.parse(
+        Parse(
             json.dumps(
                 ["null", {
                     "type": "long", "logicalType": "timestamp-micros"
                 }])))
     self.assertEqual(
         field_map["birthdayMoney"].type,
-        avro.schema.parse(
+        Parse(
             json.dumps([
                 "null",
                 {
@@ -115,36 +115,32 @@ class TestBigQueryToAvroSchema(unittest.TestCase):
                 }
             ])))
     self.assertEqual(
-        field_map["flighted"].type,
-        avro.schema.parse(json.dumps(["null", "boolean"])))
+        field_map["flighted"].type, Parse(json.dumps(["null", "boolean"])))
     self.assertEqual(
-        field_map["flighted2"].type,
-        avro.schema.parse(json.dumps(["null", "boolean"])))
+        field_map["flighted2"].type, Parse(json.dumps(["null", "boolean"])))
     self.assertEqual(
-        field_map["sound"].type,
-        avro.schema.parse(json.dumps(["null", "bytes"])))
+        field_map["sound"].type, Parse(json.dumps(["null", "bytes"])))
     self.assertEqual(
         field_map["anniversaryDate"].type,
-        avro.schema.parse(
+        Parse(
             json.dumps(["null", {
                 "type": "int", "logicalType": "date"
             }])))
     self.assertEqual(
         field_map["anniversaryDatetime"].type,
-        avro.schema.parse(json.dumps(["null", "string"])))
+        Parse(json.dumps(["null", "string"])))
     self.assertEqual(
         field_map["anniversaryTime"].type,
-        avro.schema.parse(
+        Parse(
             json.dumps(["null", {
                 "type": "long", "logicalType": "time-micros"
             }])))
     self.assertEqual(
-        field_map["geoPositions"].type,
-        avro.schema.parse(json.dumps(["null", "string"])))
+        field_map["geoPositions"].type, Parse(json.dumps(["null", "string"])))
 
     self.assertEqual(
         field_map["scion"].type,
-        avro.schema.parse(
+        Parse(
             json.dumps([
                 "null",
                 {
@@ -163,7 +159,7 @@ class TestBigQueryToAvroSchema(unittest.TestCase):
 
     self.assertEqual(
         field_map["associates"].type,
-        avro.schema.parse(
+        Parse(
             json.dumps({
                 "type": "array",
                 "items": {

--- a/sdks/python/apache_beam/io/gcp/bigquery_avro_tools_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_avro_tools_test.py
@@ -14,23 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import absolute_import
-from __future__ import division
+from __future__ import absolute_import, division
 
 import json
 import logging
 import unittest
 
+import fastavro
+
+from apache_beam.io.gcp import bigquery_avro_tools, bigquery_tools
+from apache_beam.io.gcp.bigquery_test import HttpError
+from apache_beam.io.gcp.internal.clients import bigquery
+
 try:
   from avro.schema import Parse  # avro-python3 library for Python 3
 except ImportError:
   from avro.schema import parse as Parse  # avro library for Python 2
-import fastavro
-
-from apache_beam.io.gcp import bigquery_avro_tools
-from apache_beam.io.gcp import bigquery_tools
-from apache_beam.io.gcp.bigquery_test import HttpError
-from apache_beam.io.gcp.internal.clients import bigquery
 
 
 @unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')
@@ -87,8 +86,7 @@ class TestBigQueryToAvroSchema(unittest.TestCase):
     field_map = getattr(parsed_schema, "field_map", None) or \
       getattr(parsed_schema, "fields_dict", None)
 
-    self.assertEqual(
-        field_map["number"].type, Parse(json.dumps("long")))
+    self.assertEqual(field_map["number"].type, Parse(json.dumps("long")))
     self.assertEqual(
         field_map["species"].type, Parse(json.dumps(["null", "string"])))
     self.assertEqual(
@@ -122,10 +120,9 @@ class TestBigQueryToAvroSchema(unittest.TestCase):
         field_map["sound"].type, Parse(json.dumps(["null", "bytes"])))
     self.assertEqual(
         field_map["anniversaryDate"].type,
-        Parse(
-            json.dumps(["null", {
-                "type": "int", "logicalType": "date"
-            }])))
+        Parse(json.dumps(["null", {
+            "type": "int", "logicalType": "date"
+        }])))
     self.assertEqual(
         field_map["anniversaryDatetime"].type,
         Parse(json.dumps(["null", "string"])))

--- a/sdks/python/apache_beam/io/gcp/bigquery_avro_tools_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_avro_tools_test.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import absolute_import, division
+from __future__ import absolute_import
+from __future__ import division
 
 import json
 import logging
@@ -22,7 +23,8 @@ import unittest
 
 import fastavro
 
-from apache_beam.io.gcp import bigquery_avro_tools, bigquery_tools
+from apache_beam.io.gcp import bigquery_avro_tools
+from apache_beam.io.gcp import bigquery_tools
 from apache_beam.io.gcp.bigquery_test import HttpError
 from apache_beam.io.gcp.internal.clients import bigquery
 


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
